### PR TITLE
Fix link to mapping entities on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
                 <h2>Mapping</h2>
                 <ul>
                     <li><a href="https://github.com/etjump/mapping">Mapping environment</a></li>
-                    <li><a href="https://etjump.readthedocs.io/en/latest/mapping/mapping_entities/">ETJump Entities</a>
+                    <li><a href="https://etjump.readthedocs.io/en/latest/mapping/mapping_entities.html">ETJump Entities</a>
                     </li>
                     <li><a href="https://github.com/id-tech-3-tools/ET-extra-assets">Mapping assets</a></li>
                     <li><a href="utilities/overbounce/index.html">Overbounce calculator</a></li>


### PR DESCRIPTION
Never updated this after moving the docs to new platform.